### PR TITLE
Fix on FF: wait loadeddata

### DIFF
--- a/chroma/index.js
+++ b/chroma/index.js
@@ -85,9 +85,9 @@ function loadAll () {
     this.c2 = document.getElementById("c2");
     this.ctx2 = this.c2.getContext("2d");
     let self = this;
-    this.video.addEventListener("play", function() {
-        self.width = self.video.videoWidth;
-        self.height = self.video.videoHeight;
-        self.time_callback();
-    }, false);
+    this.video.addEventListener('loadeddata', event => {
+      self.width = self.video.videoWidth
+      self.height = self.video.videoHeight
+      self.time_callback()
+    }, false)
 };


### PR DESCRIPTION
Wait `loadeddata` to have values for `videoWidth` and `videoHeight` on FF.

At leas on my _Firefox_ (66.0.3) on macOS _Mojave_ those values are `0` when setting on `play` eventListener, so waiting for `loadeddata` everything works as expected. Seems that in FF that value isn't available yet due to [not yet available media](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement#Properties)

[not-related]

Curious why you are setting `640x480` [here](https://github.com/evaferreira/limajs/blob/master/chroma/index.js#L28) but then another relations in the [canvas](https://github.com/evaferreira/limajs/blob/master/chroma/index.html#L14-L15) and [video](https://github.com/evaferreira/limajs/blob/master/chroma/styles.css#L5-L6) sizes. 
In my case (probably depends on webcam definition, etc) I see a crop of the video images that probably could be fixed unifying those values.